### PR TITLE
doc: fix assert expected string

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ const positionUrl = `/positions/${posId}/`
 
 const url = ms.buildUrl(`entity/customerorder/` + positionUrl)
 
-assert.equal(url, `entity/customerorder/positions/${posId}`)
+assert.equal(url, `https://api.moysklad.ru/api/remap/1.2/entity/customerorder/positions/${posId}`)
 ```
 
 ### parseUrl


### PR DESCRIPTION
```js
import Moysklad from 'moysklad'

import assert from 'node:assert'

const ms = new Moysklad()

const posId = '123'

const positionUrl = `/positions/${posId}/`

const url = ms.buildUrl(`entity/customerorder/` + positionUrl)

assert.equal(url, `entity/customerorder/positions/${posId}`)
// assert.equal(url, `https://api.moysklad.ru/api/remap/1.2/entity/customerorder/positions/${posId}`)
```

```
AssertionError [ERR_ASSERTION]: 'https://api.moysklad.ru/api/remap/1.2/entity/customerorder/positions/123' == 'entity/customerorder/positions/123'
```